### PR TITLE
Decodes the `userInfo` of a `DatabaseConfiguration` URI

### DIFF
--- a/lib/src/default_configurations.dart
+++ b/lib/src/default_configurations.dart
@@ -75,10 +75,10 @@ class DatabaseConfiguration extends Configuration {
     var authority = uri.userInfo.split(":");
     if (authority != null) {
       if (authority.isNotEmpty) {
-        username = authority.first;
+        username = Uri.decodeComponent(authority.first);
       }
       if (authority.length > 1) {
-        password = authority.last;
+        password = Uri.decodeComponent(authority.last);
       }
     }
   }

--- a/test/config_test.dart
+++ b/test/config_test.dart
@@ -607,6 +607,15 @@ void main() {
     expect(values.database.databaseName, "dbname");
   });
 
+  test("Database configuration as a string can contain an URL-encoded authority", () {
+    var yamlString = "port: 80\n"
+        "database: \"postgres://dart%40google.com:pass%23word@host:5432/dbname\"\n";
+
+    var values = OptionalEmbeddedContainer.fromString(yamlString);
+    expect(values.database.username, "dart@google.com");
+    expect(values.database.password, "pass#word");
+  });
+
   test("Omitting optional values in a 'decoded' config still returns succees", () {
     var yamlString = "port: 80\n"
         "database: \"postgres://host:5432/dbname\"\n";


### PR DESCRIPTION
Fixes #22 